### PR TITLE
Strip up.x suffix from Crossplane internal version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ NPROCS ?= 1
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/crossplane $(GO_PROJECT)/cmd/crank
-GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.version=$(VERSION)
+GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.version=$(shell echo $(VERSION) | sed 's/[\.,-]up.*//' )
 GO_SUBDIRS += cmd internal apis
 # disables credential providers for pulling package images
 GO_TAGS += disable_gcp disable_aws disable_azure


### PR DESCRIPTION
### Description of your changes

This PR strips the `-up.x` or `.up.y` suffixes from internal Crossplane version which causes misleading errors in package dependency resolution like https://github.com/upbound/universal-crossplane/issues/182.

Fixes https://github.com/upbound/universal-crossplane/issues/182

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
for different VERSIONs like v1.4.0-up.1, v1.5.0-rc.0.up.1.dirty, v1.5.0-rc.0.up.1.dirty; tried

```
make build
_output/bin/darwin_amd64/crank -v
```

returns expected values as v1.4.0, v1.5.0-rc.0, v1.5.0-rc.0

Also verified that, this is the same version crossplane revision controller uses by adding a temporary print line there.

[contribution process]: https://git.io/fj2m9
