### PR TITLE
Set UPBOUND_CONTEXT env var in provider deployment

### DIFF
--- a/internal/controller/pkg/revision/deployment.go
+++ b/internal/controller/pkg/revision/deployment.go
@@ -49,6 +49,9 @@ const (
 	webhookTLSCertDir       = "/webhook/tls"
 	webhookPortName         = "webhook"
 	webhookPort             = 9443
+
+	upboundCTXEnv   = "UPBOUND_CONTEXT"
+	upboundCTXValue = "uxp"
 )
 
 func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRevision, cc *v1alpha1.ControllerConfig, namespace string) (*corev1.ServiceAccount, *appsv1.Deployment, *corev1.Service) { // nolint:gocyclo
@@ -124,6 +127,10 @@ func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRe
 											FieldPath: "metadata.namespace",
 										},
 									},
+								},
+								{
+									Name:  upboundCTXEnv,
+									Value: upboundCTXValue,
 								},
 							},
 						},

--- a/internal/controller/pkg/revision/deployment_test.go
+++ b/internal/controller/pkg/revision/deployment_test.go
@@ -151,6 +151,10 @@ func deployment(provider *pkgmetav1.Provider, revision string, img string, modif
 										},
 									},
 								},
+								{
+									Name:  upboundCTXEnv,
+									Value: upboundCTXValue,
+								},
 							},
 						},
 					},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Updates provider deployment ot include setting UPBOUND_CONTEXT
environment variable.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

`make test`

[contribution process]: https://git.io/fj2m9
