### PR TITLE
revert makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,15 @@ HELM3_VERSION = v3.6.3
 -include build/makelib/k8s_tools.mk
 
 # ====================================================================================
+# Setup Helm
+
+HELM_BASE_URL = https://charts.crossplane.io
+HELM_S3_BUCKET = crossplane.charts
+HELM_CHARTS = crossplane
+HELM_CHART_LINT_ARGS_crossplane = --set nameOverride='',imagePullSecrets=''
+-include build/makelib/helm.mk
+
+# ====================================================================================
 # Setup Images
 # Due to the way that the shared build logic works, images should
 # all be in folders at the same level (no additional levels of nesting).

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ PLATFORMS ?= linux_amd64 linux_arm64 linux_arm linux_ppc64le darwin_amd64 darwin
 # ====================================================================================
 # Setup Output
 
-S3_BUCKET ?= crossplane.releases
 -include build/makelib/output.mk
 
 # ====================================================================================
@@ -43,31 +42,14 @@ HELM3_VERSION = v3.6.3
 -include build/makelib/k8s_tools.mk
 
 # ====================================================================================
-# Setup Helm
-
-HELM_BASE_URL = https://charts.crossplane.io
-HELM_S3_BUCKET = crossplane.charts
-HELM_CHARTS = crossplane
-HELM_CHART_LINT_ARGS_crossplane = --set nameOverride='',imagePullSecrets=''
--include build/makelib/helm.mk
-
-# ====================================================================================
 # Setup Images
 # Due to the way that the shared build logic works, images should
 # all be in folders at the same level (no additional levels of nesting).
 
-REGISTRY_ORGS = docker.io/crossplane
+REGISTRY_ORGS = docker.io/upbound
 IMAGES = crossplane
 OSBASEIMAGE = gcr.io/distroless/static:nonroot
 -include build/makelib/imagelight.mk
-
-# ====================================================================================
-# Setup Docs
-
-SOURCE_DOCS_DIR = docs
-DEST_DOCS_DIR = docs
-DOCS_GIT_REPO = https://$(DOCS_GIT_USR):$(DOCS_GIT_PSW)@github.com/crossplane/crossplane.github.io.git
--include build/makelib/docs.mk
 
 # ====================================================================================
 # Targets


### PR DESCRIPTION
Signed-off-by: Steven Borrelli <steve@borrelli.org>

### Description of your changes

Revert Makefile changes to the 1.8.1-up.2 release so that Upbound-specific artifacts are pushed correctly. 

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested



[contribution process]: https://git.io/fj2m9
