### PR TITLE
[release-1.8] Fetch package pull secrets from Crossplane SA and propagate to Provider Deployments

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -65,6 +65,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: POD_SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
           {{- if .Values.webhooks.enabled }}
           - name: "WEBHOOK_TLS_SECRET_NAME"
             value: webhook-tls-secret

--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -61,6 +61,7 @@ func (c *Command) Run() error {
 
 type startCommand struct {
 	Namespace            string `short:"n" help:"Namespace used to unpack and run packages." default:"crossplane-system" env:"POD_NAMESPACE"`
+	ServiceAccount       string `help:"Name of the Crossplane Service Account." default:"crossplane" env:"POD_SERVICE_ACCOUNT"`
 	CacheDir             string `short:"c" help:"Directory used for caching package images." default:"/cache" env:"CACHE_DIR"`
 	LeaderElection       bool   `short:"l" help:"Use leader election for the controller manager." default:"false" env:"LEADER_ELECTION"`
 	Registry             string `short:"r" help:"Default registry used to fetch packages when not specified in tag." default:"${default_registry}" env:"REGISTRY"`
@@ -130,6 +131,7 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 		Options:              o,
 		Cache:                xpkg.NewFsPackageCache(c.CacheDir, afero.NewOsFs()),
 		Namespace:            c.Namespace,
+		ServiceAccount:       c.ServiceAccount,
 		DefaultRegistry:      c.Registry,
 		Features:             feats,
 		WebhookTLSSecretName: c.WebhookTLSSecretName,

--- a/internal/controller/pkg/controller/options.go
+++ b/internal/controller/pkg/controller/options.go
@@ -34,6 +34,9 @@ type Options struct {
 	// Namespace used to unpack and run packages.
 	Namespace string
 
+	// ServiceAccount is the core Crossplane ServiceAccount name.
+	ServiceAccount string
+
 	// DefaultRegistry used to pull packages.
 	DefaultRegistry string
 

--- a/internal/controller/pkg/manager/reconciler.go
+++ b/internal/controller/pkg/manager/reconciler.go
@@ -156,7 +156,7 @@ func SetupProvider(mgr ctrl.Manager, o controller.Options) error {
 	if err != nil {
 		return errors.Wrap(err, errCreateK8sClient)
 	}
-	f, err := xpkg.NewK8sFetcher(cs, o.Namespace, o.FetcherOptions...)
+	f, err := xpkg.NewK8sFetcher(cs, append(o.FetcherOptions, xpkg.WithNamespace(o.Namespace), xpkg.WithServiceAccount(o.ServiceAccount))...)
 	if err != nil {
 		return errors.Wrap(err, errBuildFetcher)
 	}
@@ -191,7 +191,7 @@ func SetupConfiguration(mgr ctrl.Manager, o controller.Options) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize clientset")
 	}
-	fetcher, err := xpkg.NewK8sFetcher(clientset, o.Namespace, o.FetcherOptions...)
+	fetcher, err := xpkg.NewK8sFetcher(clientset, append(o.FetcherOptions, xpkg.WithNamespace(o.Namespace), xpkg.WithServiceAccount(o.ServiceAccount))...)
 	if err != nil {
 		return errors.Wrap(err, "cannot build fetcher")
 	}

--- a/internal/controller/pkg/resolver/reconciler.go
+++ b/internal/controller/pkg/resolver/reconciler.go
@@ -115,7 +115,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize clientset")
 	}
-	f, err := xpkg.NewK8sFetcher(cs, o.Namespace, o.FetcherOptions...)
+	f, err := xpkg.NewK8sFetcher(cs, append(o.FetcherOptions, xpkg.WithNamespace(o.Namespace), xpkg.WithServiceAccount(o.ServiceAccount))...)
 	if err != nil {
 		return errors.Wrap(err, "cannot build fetcher")
 	}

--- a/internal/controller/pkg/revision/deployment.go
+++ b/internal/controller/pkg/revision/deployment.go
@@ -54,13 +54,14 @@ const (
 	upboundCTXValue = "uxp"
 )
 
-func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRevision, cc *v1alpha1.ControllerConfig, namespace string) (*corev1.ServiceAccount, *appsv1.Deployment, *corev1.Service) { // nolint:gocyclo
+func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRevision, cc *v1alpha1.ControllerConfig, namespace string, pullSecrets []corev1.LocalObjectReference) (*corev1.ServiceAccount, *appsv1.Deployment, *corev1.Service) { // nolint:gocyclo
 	s := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            revision.GetName(),
 			Namespace:       namespace,
 			OwnerReferences: []metav1.OwnerReference{meta.AsController(meta.TypedReferenceTo(revision, v1.ProviderRevisionGroupVersionKind))},
 		},
+		ImagePullSecrets: pullSecrets,
 	}
 	pullPolicy := corev1.PullIfNotPresent
 	if revision.GetPackagePullPolicy() != nil {

--- a/internal/controller/pkg/revision/deployment_test.go
+++ b/internal/controller/pkg/revision/deployment_test.go
@@ -340,7 +340,7 @@ func TestBuildProviderDeployment(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			sa, d, svc := buildProviderDeployment(tc.fields.provider, tc.fields.revision, tc.fields.cc, namespace)
+			sa, d, svc := buildProviderDeployment(tc.fields.provider, tc.fields.revision, tc.fields.cc, namespace, nil)
 
 			if diff := cmp.Diff(tc.want.sa, sa, cmpopts.IgnoreTypes([]metav1.OwnerReference{})); diff != "" {
 				t.Errorf("-want, +got:\n%s\n", diff)

--- a/internal/controller/pkg/revision/hook.go
+++ b/internal/controller/pkg/revision/hook.go
@@ -37,7 +37,8 @@ import (
 const (
 	errNotProvider                   = "not a provider package"
 	errNotProviderRevision           = "not a provider revision"
-	errControllerConfig              = "cannot get referenced controller config"
+	errGetControllerConfig           = "cannot get referenced controller config"
+	errGetServiceAccount             = "cannot get Crossplane service account"
 	errDeleteProviderDeployment      = "cannot delete provider package deployment"
 	errDeleteProviderSA              = "cannot delete provider package service account"
 	errDeleteProviderService         = "cannot delete provider package service"
@@ -59,15 +60,17 @@ type Hooks interface {
 // ProviderHooks performs operations for a provider package that requires a
 // controller before and after the revision establishes objects.
 type ProviderHooks struct {
-	client    resource.ClientApplicator
-	namespace string
+	client         resource.ClientApplicator
+	namespace      string
+	serviceAccount string
 }
 
 // NewProviderHooks creates a new ProviderHooks.
-func NewProviderHooks(client resource.ClientApplicator, namespace string) *ProviderHooks {
+func NewProviderHooks(client resource.ClientApplicator, namespace, serviceAccount string) *ProviderHooks {
 	return &ProviderHooks{
-		client:    client,
-		namespace: namespace,
+		client:         client,
+		namespace:      namespace,
+		serviceAccount: serviceAccount,
 	}
 }
 
@@ -93,11 +96,10 @@ func (h *ProviderHooks) Pre(ctx context.Context, pkg runtime.Object, pr v1.Packa
 	if pr.GetDesiredState() != v1.PackageRevisionInactive {
 		return nil
 	}
-	cc, err := h.getControllerConfig(ctx, pr)
-	if err != nil {
-		return errors.Wrap(err, errControllerConfig)
-	}
-	s, d, svc := buildProviderDeployment(pkgProvider, pr, cc, h.namespace)
+
+	// NOTE(hasheddan): we avoid fetching pull secrets and controller config as
+	// they aren't needed to delete Deployment, ServiceAccount, and Service.
+	s, d, svc := buildProviderDeployment(pkgProvider, pr, nil, h.namespace, []corev1.LocalObjectReference{})
 	if err := h.client.Delete(ctx, d); resource.IgnoreNotFound(err) != nil {
 		return errors.Wrap(err, errDeleteProviderDeployment)
 	}
@@ -123,9 +125,13 @@ func (h *ProviderHooks) Post(ctx context.Context, pkg runtime.Object, pr v1.Pack
 	}
 	cc, err := h.getControllerConfig(ctx, pr)
 	if err != nil {
-		return errors.Wrap(err, errControllerConfig)
+		return err
 	}
-	s, d, svc := buildProviderDeployment(pkgProvider, pr, cc, h.namespace)
+	ps, err := h.getSAPullSecrets(ctx)
+	if err != nil {
+		return err
+	}
+	s, d, svc := buildProviderDeployment(pkgProvider, pr, cc, h.namespace, append(pr.GetPackagePullSecrets(), ps...))
 	if err := h.client.Apply(ctx, s); err != nil {
 		return errors.Wrap(err, errApplyProviderSA)
 	}
@@ -150,15 +156,24 @@ func (h *ProviderHooks) Post(ctx context.Context, pkg runtime.Object, pr v1.Pack
 	return nil
 }
 
-func (h *ProviderHooks) getControllerConfig(ctx context.Context, pr v1.PackageRevision) (*v1alpha1.ControllerConfig, error) {
-	var cc *v1alpha1.ControllerConfig
-	if pr.GetControllerConfigRef() != nil {
-		cc = &v1alpha1.ControllerConfig{}
-		if err := h.client.Get(ctx, types.NamespacedName{Name: pr.GetControllerConfigRef().Name}, cc); err != nil {
-			return nil, errors.Wrap(err, errControllerConfig)
-		}
+func (h *ProviderHooks) getSAPullSecrets(ctx context.Context) ([]corev1.LocalObjectReference, error) {
+	sa := &corev1.ServiceAccount{}
+	if err := h.client.Get(ctx, types.NamespacedName{
+		Namespace: h.namespace,
+		Name:      h.serviceAccount,
+	}, sa); err != nil {
+		return []corev1.LocalObjectReference{}, errors.Wrap(err, errGetServiceAccount)
 	}
-	return cc, nil
+	return sa.ImagePullSecrets, nil
+}
+
+func (h *ProviderHooks) getControllerConfig(ctx context.Context, pr v1.PackageRevision) (*v1alpha1.ControllerConfig, error) {
+	if pr.GetControllerConfigRef() == nil {
+		return nil, nil
+	}
+	cc := &v1alpha1.ControllerConfig{}
+	err := h.client.Get(ctx, types.NamespacedName{Name: pr.GetControllerConfigRef().Name}, cc)
+	return cc, errors.Wrap(err, errGetControllerConfig)
 }
 
 // ConfigurationHooks performs operations for a configuration package before and

--- a/internal/controller/pkg/revision/hook_test.go
+++ b/internal/controller/pkg/revision/hook_test.go
@@ -33,6 +33,7 @@ import (
 
 	pkgmetav1 "github.com/crossplane/crossplane/apis/pkg/meta/v1"
 	v1 "github.com/crossplane/crossplane/apis/pkg/v1"
+	"github.com/crossplane/crossplane/apis/pkg/v1alpha1"
 )
 
 var (
@@ -290,6 +291,8 @@ func TestHookPre(t *testing.T) {
 
 func TestHookPost(t *testing.T) {
 	errBoom := errors.New("boom")
+	saName := "crossplane"
+	saNamespace := "crossplane-system"
 
 	type args struct {
 		hook Hooks
@@ -335,10 +338,12 @@ func TestHookPost(t *testing.T) {
 				},
 			},
 		},
-		"ErrProviderApplySA": {
-			reason: "Should return error if we fail to apply service account for active providerrevision.",
+		"ErrGetSA": {
+			reason: "Should return error if we fail to get core Crossplane ServiceAccount.",
 			args: args{
 				hook: &ProviderHooks{
+					namespace:      saNamespace,
+					serviceAccount: saName,
 					client: resource.ClientApplicator{
 						Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
 							switch o.(type) {
@@ -349,6 +354,75 @@ func TestHookPost(t *testing.T) {
 							}
 							return nil
 						}),
+						Client: &test.MockClient{
+							MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+								switch obj.(type) {
+								case *corev1.ServiceAccount:
+									if key.Name != saName {
+										t.Errorf("unexpected ServiceAccount name: %s", key.Name)
+									}
+									if key.Namespace != saNamespace {
+										t.Errorf("unexpected ServiceAccount Namespace: %s", key.Namespace)
+									}
+									return errBoom
+								default:
+									return nil
+								}
+							},
+						},
+					},
+				},
+				pkg: &pkgmetav1.Provider{},
+				rev: &v1.ProviderRevision{
+					Spec: v1.PackageRevisionSpec{
+						DesiredState: v1.PackageRevisionActive,
+					},
+				},
+			},
+			want: want{
+				rev: &v1.ProviderRevision{
+					Spec: v1.PackageRevisionSpec{
+						DesiredState: v1.PackageRevisionActive,
+					},
+				},
+				err: errors.Wrap(errBoom, errGetServiceAccount),
+			},
+		},
+		"ErrProviderApplySA": {
+			reason: "Should return error if we fail to apply service account for active providerrevision.",
+			args: args{
+				hook: &ProviderHooks{
+					namespace:      saNamespace,
+					serviceAccount: saName,
+					client: resource.ClientApplicator{
+						Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
+							switch o.(type) {
+							case *appsv1.Deployment:
+								return nil
+							case *corev1.ServiceAccount:
+								return errBoom
+							}
+							return nil
+						}),
+						Client: &test.MockClient{
+							MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+								switch o := obj.(type) {
+								case *corev1.ServiceAccount:
+									if key.Name != saName {
+										t.Errorf("unexpected ServiceAccount name: %s", key.Name)
+									}
+									if key.Namespace != saNamespace {
+										t.Errorf("unexpected ServiceAccount Namespace: %s", key.Namespace)
+									}
+									*o = corev1.ServiceAccount{
+										ImagePullSecrets: []corev1.LocalObjectReference{{}},
+									}
+									return nil
+								default:
+									return errBoom
+								}
+							},
+						},
 					},
 				},
 				pkg: &pkgmetav1.Provider{},
@@ -371,12 +445,24 @@ func TestHookPost(t *testing.T) {
 			reason: "Should return error if we fail to get controller config for active provider revision.",
 			args: args{
 				hook: &ProviderHooks{
+					namespace:      saNamespace,
+					serviceAccount: saName,
 					client: resource.ClientApplicator{
 						Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
 							return nil
 						}),
 						Client: &test.MockClient{
-							MockGet: test.NewMockGetFn(errBoom),
+							MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+								switch obj.(type) {
+								case *v1alpha1.ControllerConfig:
+									if key.Name != "custom-config" {
+										t.Errorf("unexpected Controller Config name: %s", key.Name)
+									}
+									return errBoom
+								default:
+									return nil
+								}
+							},
 						},
 					},
 				},
@@ -399,13 +485,15 @@ func TestHookPost(t *testing.T) {
 						},
 					},
 				},
-				err: errors.Wrap(errors.Wrap(errBoom, errControllerConfig), errControllerConfig),
+				err: errors.Wrap(errBoom, errGetControllerConfig),
 			},
 		},
 		"ErrProviderApplyDeployment": {
 			reason: "Should return error if we fail to apply deployment for active provider revision.",
 			args: args{
 				hook: &ProviderHooks{
+					namespace:      saNamespace,
+					serviceAccount: saName,
 					client: resource.ClientApplicator{
 						Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
 							switch o.(type) {
@@ -416,6 +504,25 @@ func TestHookPost(t *testing.T) {
 							}
 							return nil
 						}),
+						Client: &test.MockClient{
+							MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+								switch o := obj.(type) {
+								case *corev1.ServiceAccount:
+									if key.Name != saName {
+										t.Errorf("unexpected ServiceAccount name: %s", key.Name)
+									}
+									if key.Namespace != saNamespace {
+										t.Errorf("unexpected ServiceAccount Namespace: %s", key.Namespace)
+									}
+									*o = corev1.ServiceAccount{
+										ImagePullSecrets: []corev1.LocalObjectReference{{}},
+									}
+									return nil
+								default:
+									return errBoom
+								}
+							},
+						},
 					},
 				},
 				pkg: &pkgmetav1.Provider{},
@@ -438,6 +545,8 @@ func TestHookPost(t *testing.T) {
 			reason: "Should return error if deployment is unavailable for provider revision.",
 			args: args{
 				hook: &ProviderHooks{
+					namespace:      saNamespace,
+					serviceAccount: saName,
 					client: resource.ClientApplicator{
 						Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
 							d, ok := o.(*appsv1.Deployment)
@@ -451,6 +560,25 @@ func TestHookPost(t *testing.T) {
 							}}
 							return nil
 						}),
+						Client: &test.MockClient{
+							MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+								switch o := obj.(type) {
+								case *corev1.ServiceAccount:
+									if key.Name != saName {
+										t.Errorf("unexpected ServiceAccount name: %s", key.Name)
+									}
+									if key.Namespace != saNamespace {
+										t.Errorf("unexpected ServiceAccount Namespace: %s", key.Namespace)
+									}
+									*o = corev1.ServiceAccount{
+										ImagePullSecrets: []corev1.LocalObjectReference{{}},
+									}
+									return nil
+								default:
+									return errBoom
+								}
+							},
+						},
 					},
 				},
 				pkg: &pkgmetav1.Provider{},
@@ -473,10 +601,31 @@ func TestHookPost(t *testing.T) {
 			reason: "Should not return error if successfully applied service account and deployment for active provider revision.",
 			args: args{
 				hook: &ProviderHooks{
+					namespace:      saNamespace,
+					serviceAccount: saName,
 					client: resource.ClientApplicator{
 						Applicator: resource.ApplyFn(func(_ context.Context, o client.Object, _ ...resource.ApplyOption) error {
 							return nil
 						}),
+						Client: &test.MockClient{
+							MockGet: func(_ context.Context, key client.ObjectKey, obj client.Object) error {
+								switch o := obj.(type) {
+								case *corev1.ServiceAccount:
+									if key.Name != saName {
+										t.Errorf("unexpected ServiceAccount name: %s", key.Name)
+									}
+									if key.Namespace != saNamespace {
+										t.Errorf("unexpected ServiceAccount Namespace: %s", key.Namespace)
+									}
+									*o = corev1.ServiceAccount{
+										ImagePullSecrets: []corev1.LocalObjectReference{{}},
+									}
+									return nil
+								default:
+									return errBoom
+								}
+							},
+						},
 					},
 				},
 				pkg: &pkgmetav1.Provider{},

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -226,7 +226,7 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 	if err != nil {
 		return errors.New("cannot build object scheme for package parser")
 	}
-	fetcher, err := xpkg.NewK8sFetcher(clientset, o.Namespace, o.FetcherOptions...)
+	fetcher, err := xpkg.NewK8sFetcher(clientset, append(o.FetcherOptions, xpkg.WithNamespace(o.Namespace), xpkg.WithServiceAccount(o.ServiceAccount))...)
 	if err != nil {
 		return errors.Wrap(err, "cannot build fetcher for package parser")
 	}
@@ -237,7 +237,7 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 		WithHooks(NewProviderHooks(resource.ClientApplicator{
 			Client:     mgr.GetClient(),
 			Applicator: resource.NewAPIPatchingApplicator(mgr.GetClient()),
-		}, o.Namespace)),
+		}, o.Namespace, o.ServiceAccount)),
 		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace)),
 		WithNewPackageRevisionFn(nr),
 		WithParser(parser.New(metaScheme, objScheme)),
@@ -276,7 +276,7 @@ func SetupConfigurationRevision(mgr ctrl.Manager, o controller.Options) error {
 	if err != nil {
 		return errors.New("cannot build object scheme for package parser")
 	}
-	f, err := xpkg.NewK8sFetcher(cs, o.Namespace, o.FetcherOptions...)
+	f, err := xpkg.NewK8sFetcher(cs, append(o.FetcherOptions, xpkg.WithNamespace(o.Namespace), xpkg.WithServiceAccount(o.ServiceAccount))...)
 	if err != nil {
 		return errors.Wrap(err, "cannot build fetcher for package parser")
 	}

--- a/internal/xpkg/fetch.go
+++ b/internal/xpkg/fetch.go
@@ -54,9 +54,10 @@ type Fetcher interface {
 
 // K8sFetcher uses kubernetes credentials to fetch package images.
 type K8sFetcher struct {
-	client    kubernetes.Interface
-	namespace string
-	transport http.RoundTripper
+	client         kubernetes.Interface
+	namespace      string
+	serviceAccount string
+	transport      http.RoundTripper
 }
 
 // FetcherOpt can be used to add optional parameters to NewK8sFetcher
@@ -98,11 +99,28 @@ func WithCustomCA(rootCAs *x509.CertPool) FetcherOpt {
 	}
 }
 
+// WithNamespace is a FetcherOpt that sets the Namespace for fetching package
+// pull secrets.
+func WithNamespace(ns string) FetcherOpt {
+	return func(k *K8sFetcher) error {
+		k.namespace = ns
+		return nil
+	}
+}
+
+// WithServiceAccount is a FetcherOpt that sets the ServiceAccount name for
+// fetching package pull secrets.
+func WithServiceAccount(sa string) FetcherOpt {
+	return func(k *K8sFetcher) error {
+		k.serviceAccount = sa
+		return nil
+	}
+}
+
 // NewK8sFetcher creates a new K8sFetcher.
-func NewK8sFetcher(client kubernetes.Interface, namespace string, opts ...FetcherOpt) (*K8sFetcher, error) {
+func NewK8sFetcher(client kubernetes.Interface, opts ...FetcherOpt) (*K8sFetcher, error) {
 	k := &K8sFetcher{
 		client:    client,
-		namespace: namespace,
 		transport: remote.DefaultTransport.Clone(),
 	}
 
@@ -118,8 +136,9 @@ func NewK8sFetcher(client kubernetes.Interface, namespace string, opts ...Fetche
 // Fetch fetches a package image.
 func (i *K8sFetcher) Fetch(ctx context.Context, ref name.Reference, secrets ...string) (v1.Image, error) {
 	auth, err := k8schain.New(ctx, i.client, k8schain.Options{
-		Namespace:        i.namespace,
-		ImagePullSecrets: secrets,
+		Namespace:          i.namespace,
+		ServiceAccountName: i.serviceAccount,
+		ImagePullSecrets:   secrets,
 	})
 	if err != nil {
 		return nil, err
@@ -130,8 +149,9 @@ func (i *K8sFetcher) Fetch(ctx context.Context, ref name.Reference, secrets ...s
 // Head fetches a package descriptor.
 func (i *K8sFetcher) Head(ctx context.Context, ref name.Reference, secrets ...string) (*v1.Descriptor, error) {
 	auth, err := k8schain.New(ctx, i.client, k8schain.Options{
-		Namespace:        i.namespace,
-		ImagePullSecrets: secrets,
+		Namespace:          i.namespace,
+		ServiceAccountName: i.serviceAccount,
+		ImagePullSecrets:   secrets,
 	})
 	if err != nil {
 		return nil, err
@@ -150,8 +170,9 @@ func (i *K8sFetcher) Head(ctx context.Context, ref name.Reference, secrets ...st
 // Tags fetches a package's tags.
 func (i *K8sFetcher) Tags(ctx context.Context, ref name.Reference, secrets ...string) ([]string, error) {
 	auth, err := k8schain.New(ctx, i.client, k8schain.Options{
-		Namespace:        i.namespace,
-		ImagePullSecrets: secrets,
+		Namespace:          i.namespace,
+		ServiceAccountName: i.serviceAccount,
+		ImagePullSecrets:   secrets,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

This changeset updates to consume package pull secrets from the Crossplane `ServiceAccount`, rather than the previous behavior of falling back to the `default` `ServiceAccount`. It also propagates secrets from the `ServiceAccount` to the `ServiceAccount` of any Provider `Deployment`. This enables installing chains of private dependencies by attaching all required package pull secrets to the Crossplane `ServiceAccount`.

Lastly, any package pull secrets on a `ProviderRevision` are propagated to their `Deployment` as well, but they are not propagated to dependencies. We may opt to do this in the future, but there is some subtleties around shared dependents that make it more complex to do so. Because propagating the package pull secrets from the `ServiceAccount` makes it possible to install chains of private dependencies, we defer propagating revision secrets to dependencies until a future date.

Backport of https://github.com/crossplane/crossplane/pull/3332

Part of https://github.com/upbound/universal-crossplane/issues/289

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->


See https://github.com/crossplane/crossplane/pull/3332 for testing steps.

[contribution process]: https://git.io/fj2m9
