### PR TITLE
[release-1.10]: Explicitly setting release namespace on resources

### DIFF
--- a/cluster/charts/crossplane/templates/deployment.yaml
+++ b/cluster/charts/crossplane/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "crossplane.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}
     release: {{ .Release.Name }}

--- a/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-deployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "crossplane.name" . }}-rbac-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}-rbac-manager
     release: {{ .Release.Name }}

--- a/cluster/charts/crossplane/templates/rbac-manager-serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: rbac-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}
     {{- include "crossplane.labels" . | indent 4 }}

--- a/cluster/charts/crossplane/templates/secret.yaml
+++ b/cluster/charts/crossplane/templates/secret.yaml
@@ -8,5 +8,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: webhook-tls-secret
+  namespace: {{ .Release.Namespace }}
 type: Opaque
 {{- end }}

--- a/cluster/charts/crossplane/templates/service.yaml
+++ b/cluster/charts/crossplane/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "crossplane.name" . }}-webhooks
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}
     release: {{ .Release.Name }}

--- a/cluster/charts/crossplane/templates/serviceaccount.yaml
+++ b/cluster/charts/crossplane/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "crossplane.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "crossplane.name" . }}
     {{- include "crossplane.labels" . | indent 4 }}


### PR DESCRIPTION
### Description of your changes

We need this for EKS Addon artifact.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
