### PR TITLE
Add support for alpha provider identity support

### DIFF
--- a/cmd/crossplane/core/core.go
+++ b/cmd/crossplane/core/core.go
@@ -82,6 +82,11 @@ type startCommand struct {
 	EnableEnvironmentConfigs   bool `group:"Alpha Features:" help:"Enable support for EnvironmentConfigs."`
 	EnableExternalSecretStores bool `group:"Alpha Features:" help:"Enable support for External Secret Stores."`
 	EnableCompositionFunctions bool `group:"Alpha Features:" help:"Enable support for Composition Functions."`
+	// NOTE(hasheddan): this feature is unlikely to graduate from alpha status
+	// and should be removed when a runtime interface is introduced upstream.
+	// See https://github.com/crossplane/crossplane/issues/2671 for more
+	// information.
+	EnableProviderIdentity bool `group:"Alpha Features:" help:"Enable support for Provider identity."`
 }
 
 // Run core Crossplane controllers.
@@ -128,6 +133,10 @@ func (c *startCommand) Run(s *runtime.Scheme, log logging.Logger) error { //noli
 	if c.EnableCompositionFunctions {
 		feats.Enable(features.EnableAlphaCompositionFunctions)
 		log.Info("Alpha feature enabled", "flag", features.EnableAlphaCompositionFunctions)
+	}
+	if c.EnableProviderIdentity {
+		feats.Enable(features.EnableProviderIdentity)
+		log.Info("Alpha feature enabled", "flag", features.EnableProviderIdentity)
 	}
 
 	o := controller.Options{

--- a/internal/controller/pkg/revision/deployment.go
+++ b/internal/controller/pkg/revision/deployment.go
@@ -36,6 +36,7 @@ var (
 	allowPrivilegeEscalation = false
 	privileged               = false
 	runAsNonRoot             = true
+	readOnly                 = true
 )
 
 // Providers are expected to use port 8080 if they expose Prometheus metrics,
@@ -50,12 +51,16 @@ const (
 	webhookPortName         = "webhook"
 	webhookPort             = 9443
 
+	proidcVolumeName = "proidc"
+	proidcDriverName = "proidc.csi.upbound.io"
+	proidcMountPath  = "/var/run/secrets/upbound.io/provider"
+
 	upboundCTXEnv   = "UPBOUND_CONTEXT"
 	upboundCTXValue = "uxp"
 )
 
 //nolint:gocyclo // TODO(negz): Can this be refactored for less complexity (and fewer arguments?)
-func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRevision, cc *v1alpha1.ControllerConfig, namespace string, pullSecrets []corev1.LocalObjectReference) (*corev1.ServiceAccount, *appsv1.Deployment, *corev1.Service) {
+func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRevision, cc *v1alpha1.ControllerConfig, namespace string, pullSecrets []corev1.LocalObjectReference, providerIdentity bool) (*corev1.ServiceAccount, *appsv1.Deployment, *corev1.Service) {
 	s := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            revision.GetName(),
@@ -255,6 +260,24 @@ func buildProviderDeployment(provider *pkgmetav1.Provider, revision v1.PackageRe
 			d.Spec.Template.Spec.Containers[0].Env = append(d.Spec.Template.Spec.Containers[0].Env, cc.Spec.Env...)
 		}
 	}
+
+	if providerIdentity {
+		d.Spec.Template.Spec.Volumes = append(d.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: proidcVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				CSI: &corev1.CSIVolumeSource{
+					Driver:   proidcDriverName,
+					ReadOnly: &readOnly,
+				},
+			},
+		})
+		d.Spec.Template.Spec.Containers[0].VolumeMounts = append(d.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+			Name:      proidcVolumeName,
+			ReadOnly:  readOnly,
+			MountPath: proidcMountPath,
+		})
+	}
+
 	for k, v := range d.Spec.Selector.MatchLabels { // ensure the template matches the selector
 		templateLabels[k] = v
 	}

--- a/internal/controller/pkg/revision/deployment_test.go
+++ b/internal/controller/pkg/revision/deployment_test.go
@@ -170,9 +170,10 @@ func deployment(provider *pkgmetav1.Provider, revision string, img string, modif
 
 func TestBuildProviderDeployment(t *testing.T) {
 	type args struct {
-		provider *pkgmetav1.Provider
-		revision *v1.ProviderRevision
-		cc       *v1alpha1.ControllerConfig
+		provider         *pkgmetav1.Provider
+		revision         *v1.ProviderRevision
+		cc               *v1alpha1.ControllerConfig
+		providerIdentity bool
 	}
 	type want struct {
 		sa  *corev1.ServiceAccount
@@ -271,6 +272,35 @@ func TestBuildProviderDeployment(t *testing.T) {
 				svc: service(providerWithoutImage, revisionWithoutCC),
 			},
 		},
+		"NoImgNoCCWithProviderIdentity": {
+			reason: "If provider identity is enabled, a proidc volume should be added.",
+			fields: args{
+				provider:         providerWithoutImage,
+				revision:         revisionWithoutCC,
+				cc:               nil,
+				providerIdentity: true,
+			},
+			want: want{
+				sa: serviceaccount(revisionWithoutCC),
+				d: deployment(providerWithoutImage, revisionWithCC.GetName(), pkgImg, withAdditionalVolume(corev1.Volume{
+					Name: proidcVolumeName,
+					VolumeSource: corev1.VolumeSource{
+						CSI: &corev1.CSIVolumeSource{
+							Driver:   proidcDriverName,
+							ReadOnly: &readOnly,
+							// TODO(hasheddan): set volume attributes based on package
+							// contents.
+						},
+					},
+				}),
+					withAdditionalVolumeMount(corev1.VolumeMount{
+						Name:      proidcVolumeName,
+						ReadOnly:  readOnly,
+						MountPath: proidcMountPath,
+					})),
+				svc: service(providerWithoutImage, revisionWithoutCC),
+			},
+		},
 		"ImgNoCCWithWebhookTLS": {
 			reason: "If the webhook tls secret name is given, then the deployment should be configured to serve behind the given service.",
 			fields: args{
@@ -338,7 +368,7 @@ func TestBuildProviderDeployment(t *testing.T) {
 
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			sa, d, svc := buildProviderDeployment(tc.fields.provider, tc.fields.revision, tc.fields.cc, namespace, nil)
+			sa, d, svc := buildProviderDeployment(tc.fields.provider, tc.fields.revision, tc.fields.cc, namespace, nil, tc.fields.providerIdentity)
 
 			if diff := cmp.Diff(tc.want.sa, sa, cmpopts.IgnoreTypes([]metav1.OwnerReference{})); diff != "" {
 				t.Errorf("-want, +got:\n%s\n", diff)

--- a/internal/controller/pkg/revision/reconciler.go
+++ b/internal/controller/pkg/revision/reconciler.go
@@ -49,6 +49,7 @@ import (
 	"github.com/crossplane/crossplane/apis/pkg/v1beta1"
 	"github.com/crossplane/crossplane/internal/controller/pkg/controller"
 	"github.com/crossplane/crossplane/internal/dag"
+	"github.com/crossplane/crossplane/internal/features"
 	"github.com/crossplane/crossplane/internal/version"
 	"github.com/crossplane/crossplane/internal/xpkg"
 )
@@ -248,7 +249,7 @@ func SetupProviderRevision(mgr ctrl.Manager, o controller.Options) error {
 		WithHooks(NewProviderHooks(resource.ClientApplicator{
 			Client:     mgr.GetClient(),
 			Applicator: resource.NewAPIPatchingApplicator(mgr.GetClient()),
-		}, o.Namespace, o.ServiceAccount)),
+		}, o.Namespace, o.ServiceAccount, o.Features.Enabled(features.EnableProviderIdentity))),
 		WithEstablisher(NewAPIEstablisher(mgr.GetClient(), o.Namespace)),
 		WithNewPackageRevisionFn(nr),
 		WithParser(parser.New(metaScheme, objScheme)),

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -34,9 +34,11 @@ const (
 	// External Secret Stores. See the below design for more details.
 	// https://github.com/crossplane/crossplane/blob/390ddd/design/design-doc-external-secret-stores.md
 	EnableAlphaExternalSecretStores feature.Flag = "EnableAlphaExternalSecretStores"
-
 	// EnableAlphaCompositionFunctions enables alpha support for composition
 	// functions. See the below design for more details.
 	// https://github.com/crossplane/crossplane/blob/9ee7a2/design/design-doc-composition-functions.md
 	EnableAlphaCompositionFunctions feature.Flag = "EnableAlphaCompositionFunctions"
+	// EnableProviderIdentity enables alpha support for Provider identity. This
+	// feature is only available when running on Upbound.
+	EnableProviderIdentity feature.Flag = "EnableProviderIdentity"
 )


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Adds support for enabling provider identity. This feature is unlikely to graduate from alpha, and will likely be replaced by an implementation of the runtime interface. It is disabled by default and is only functional when running on Upbound.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Verified that we are mounting successfully when the `--enable-provider-identity` flag is set and that we are not when it is not.

```yaml
apiVersion: v1
kind: Pod
metadata:
  creationTimestamp: "2023-02-10T20:28:56Z"
  generateName: upbound-provider-gcp-5145d928dcf9-67889956cf-
  labels:
    pkg.crossplane.io/provider: provider-gcp
    pkg.crossplane.io/revision: upbound-provider-gcp-5145d928dcf9
    pod-template-hash: 67889956cf
  name: upbound-provider-gcp-5145d928dcf9-67889956cf-sshrt
  namespace: crossplane-system
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: ReplicaSet
    name: upbound-provider-gcp-5145d928dcf9-67889956cf
    uid: 01b8ce14-bca2-4e57-8879-19daa6296467
  resourceVersion: "2136"
  uid: d5d06a60-1495-4bb2-ac97-2117ec32b208
spec:
  containers:
  - env:
    - name: POD_NAMESPACE
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.namespace
    - name: UPBOUND_CONTEXT
      value: uxp
    image: xpkg.upbound.io/upbound/provider-gcp:v0.27.0
    imagePullPolicy: IfNotPresent
    name: provider-gcp
    ports:
    - containerPort: 8080
      name: metrics
      protocol: TCP
    resources: {}
    securityContext:
      allowPrivilegeEscalation: false
      privileged: false
      runAsGroup: 2000
      runAsNonRoot: true
      runAsUser: 2000
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /var/run/secrets/upbound.io/provider
      name: proidc
      readOnly: true
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-dnbk4
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  nodeName: build-2f418432-inttests-control-plane
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext:
    runAsGroup: 2000
    runAsNonRoot: true
    runAsUser: 2000
  serviceAccount: upbound-provider-gcp-5145d928dcf9
  serviceAccountName: upbound-provider-gcp-5145d928dcf9
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - csi:
      driver: proidc.csi.upbound.io
      readOnly: true
    name: proidc
  - name: kube-api-access-dnbk4
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          expirationSeconds: 3607
          path: token
      - configMap:
          items:
          - key: ca.crt
            path: ca.crt
          name: kube-root-ca.crt
      - downwardAPI:
          items:
          - fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
            path: namespace
```

[contribution process]: https://git.io/fj2m9
