### PR TITLE
Backport: Strip up.x suffix from Crossplane internal version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ NPROCS ?= 1
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/crossplane $(GO_PROJECT)/cmd/crank $(GO_PROJECT)/cmd/xfn
-GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.version=$(VERSION)
+GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.version=$(shell echo $(VERSION) | sed 's/[\.,-]up.*//' )
 GO_SUBDIRS += cmd internal apis
 GO111MODULE = on
 GOLANGCILINT_VERSION = 1.52.2

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ HELM3_VERSION = v3.6.3
 
 REGISTRY_ORGS = docker.io/upbound
 IMAGES = crossplane xfn
-OSBASEIMAGE = gcr.io/distroless/static:nonroot
 -include build/makelib/imagelight.mk
 
 # ====================================================================================

--- a/cluster/local/integration_tests.sh
+++ b/cluster/local/integration_tests.sh
@@ -42,7 +42,8 @@ SAFEHOSTARCH="${SAFEHOSTARCH:-amd64}"
 BUILD_IMAGE="${BUILD_REGISTRY}/${PROJECT_NAME}-${SAFEHOSTARCH}"
 
 helm_tag="$(cat ${projectdir}/_output/version)"
-CROSSPLANE_IMAGE="upbound/${PROJECT_NAME}:${helm_tag}"
+CROSSPLANE_IMAGE_REPOSITORY="upbound/${PROJECT_NAME}"
+CROSSPLANE_IMAGE="${CROSSPLANE_IMAGE_REPOSITORY}:${helm_tag}"
 K8S_CLUSTER="${K8S_CLUSTER:-${BUILD_REGISTRY}-inttests}"
 
 CROSSPLANE_NAMESPACE="crossplane-system"
@@ -71,14 +72,7 @@ docker tag "${BUILD_IMAGE}" "${CROSSPLANE_IMAGE}"
 "${KIND}" load docker-image "${CROSSPLANE_IMAGE}" --name="${K8S_CLUSTER}"
 
 echo_step "installing helm package(s) into \"${CROSSPLANE_NAMESPACE}\" namespace"
-
-# We removed helm.mk since we don't need/want to publish helm charts. However,
-# we lost templating functionality from values.yaml.tmpl which is handled with
-# the following lines instead.
-cp "${projectdir}/cluster/charts/${PROJECT_NAME}/values.yaml.tmpl" "${projectdir}/cluster/charts/${PROJECT_NAME}/values.yaml"
-sed -i -e "s|%%VERSION%%|${helm_tag}|g" "${projectdir}/cluster/charts/${PROJECT_NAME}/values.yaml"
-
-"${HELM3}" install --create-namespace -n "${CROSSPLANE_NAMESPACE}" "${PROJECT_NAME}" "${projectdir}/cluster/charts/${PROJECT_NAME}" --set replicas=2,args={'-d'},rbacManager.replicas=2,rbacManager.args={'-d'},image.pullPolicy=Never,imagePullSecrets='',image.tag=${helm_tag}
+"${HELM3}" install --create-namespace -n "${CROSSPLANE_NAMESPACE}" "${PROJECT_NAME}" "${projectdir}/cluster/charts/${PROJECT_NAME}" --set replicas=2,args={'-d'},rbacManager.replicas=2,rbacManager.args={'-d'},image.pullPolicy=Never,imagePullSecrets='',image.tag=${helm_tag},image.repository=${CROSSPLANE_IMAGE_REPOSITORY}
 
 echo_step "waiting for deployment ${PROJECT_NAME} rollout to finish"
 "${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" rollout status "deploy/${PROJECT_NAME}" --timeout=2m


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Backport forgotten commit to 1.12, #17.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N.A.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
