### PR TITLE
[release-1.11] Backport: Strip up.x suffix from Crossplane internal version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 GO_REQUIRED_VERSION = 1.19
 
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/crossplane $(GO_PROJECT)/cmd/crank $(GO_PROJECT)/cmd/xfn
-GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.version=$(VERSION)
+GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.version=$(shell echo $(VERSION) | sed 's/[\.,-]up.*//' )
 GO_SUBDIRS += cmd internal apis
 GO111MODULE = on
 GOLANGCILINT_VERSION = 1.50.1


### PR DESCRIPTION


### Description of your changes

Backports https://github.com/upbound/crossplane/pull/17 to release-1.11

Signed-off-by: Hasan Turken <turkenh@gmail.com>
(cherry picked from commit c05a12fcc7bd1fa5218de991a0586df6ccc62b5f)

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

N/A

[contribution process]: https://git.io/fj2m9
