### PR TITLE
[ release-1.12] Backport: Helm Chart: add locks to the RBAC for pkg.crossplane.io

### DIFF
--- a/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
+++ b/cluster/charts/crossplane/templates/rbac-manager-managed-clusterroles.yaml
@@ -101,7 +101,7 @@ rules:
   verbs: ["*"]
 - apiGroups:
   - pkg.crossplane.io
-  resources: [providers, configurations, providerrevisions, configurationrevisions]
+  resources: [locks, providers, configurations, providerrevisions, configurationrevisions]
   verbs: ["*"]
 # Crossplane administrators have access to view CRDs in order to debug XRDs.
 - apiGroups: [apiextensions.k8s.io]
@@ -137,7 +137,7 @@ rules:
   verbs: ["*"]
 - apiGroups:
   - pkg.crossplane.io
-  resources: [providers, configurations, providerrevisions, configurationrevisions]
+  resources: [locks, providers, configurations, providerrevisions, configurationrevisions]
   verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -164,7 +164,7 @@ rules:
   verbs: [get, list, watch]
 - apiGroups:
   - pkg.crossplane.io
-  resources: [providers, configurations, providerrevisions, configurationrevisions]
+  resources: [locks, providers, configurations, providerrevisions, configurationrevisions]
   verbs: [get, list, watch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
In the Upbound managed environment, users are not able to upgrade from the monolithic providers to SSOPs following [1] due to missing permissions to the lock. This changes add `locks.pkg.crossplane.io` to the RBACs for admin, view and edit.

[1] https://docs.upbound.io/knowledge-base/migrate-to-provider-families

Signed-off-by: Ben Howard <me@muggle.dev>
(cherry picked from commit d7a751feaac230dc69307ab4939605e2faafb54c)

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does, and how it is covered by tests.
Be proactive - direct your reviewers' attention to anything that needs special
consideration.

You MUST either [x] check or ~strikethrough~ every item in the checklist below.

We love pull requests that fix an open issue. If yours does, use the below line
to indicate which issue it fixes, for example "Fixes #500".
-->

Backport https://github.com/crossplane/crossplane/pull/4267 to 1.12 to be part of the next 1.12-up.2 release.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit **and** E2E tests for my change.
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

[contribution process]: https://git.io/fj2m9