### PR TITLE
Update default branch in CI and fix pushing to marketplace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
       - release-*
   pull_request: {}
   workflow_dispatch: {}
@@ -402,6 +402,16 @@ jobs:
           username: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR }}
           password: ${{ secrets.UPBOUND_MARKETPLACE_PUSH_ROBOT_PSW }}
 
+      - name: Publish Artifacts to Marketplace, DockerHub
+        run: make -j2 publish BRANCH_NAME=${GITHUB_REF##*/}
+
+      - name: Promote Artifacts in DockerHub
+        if: github.ref == 'refs/heads/main' && env.DOCKER_USR != ''
+        run: make -j2 promote
+        env:
+          BRANCH_NAME: main
+          CHANNEL: main
+
       - name: Login to Spaces Artifacts Registry
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3
         if: env.XPKG_ACCESS_ID != ''
@@ -410,15 +420,18 @@ jobs:
           username: ${{ secrets.XPKG_ACCESS_ID }}
           password: ${{ secrets.XPKG_TOKEN }}
 
-      - name: Publish Artifacts to Marketplace, DockerHub
+      - name: Publish Artifacts to Spaces Artifacts Registry
         run: make -j2 publish BRANCH_NAME=${GITHUB_REF##*/}
+        env:
+          REGISTRY_ORGS: xpkg.upbound.io/spaces-artifacts
 
-      - name: Promote Artifacts in DockerHub
-        if: github.ref == 'refs/heads/master' && env.DOCKER_USR != ''
+      - name: Promote Artifacts in Spaces Artifacts Registry
+        if: github.ref == 'refs/heads/main' && env.DOCKER_USR != ''
         run: make -j2 promote
         env:
-          BRANCH_NAME: master
-          CHANNEL: master
+          REGISTRY_ORGS: xpkg.upbound.io/spaces-artifacts
+          BRANCH_NAME: main
+          CHANNEL: main
 
   fuzz-test:
     runs-on: ubuntu-22.04
@@ -468,13 +481,13 @@ jobs:
         with:
           input: apis
 
-      - name: Detect Breaking Changes in Protocol Buffers (Master Branch)
+      - name: Detect Breaking Changes in Protocol Buffers (Main Branch)
         uses: bufbuild/buf-breaking-action@a074e988ee34efcd4927079e79c611f428354c01 # v1
-        # We want to run this for the master branch, and PRs.
+        # We want to run this for the main branch, and PRs.
         if: ${{ ! startsWith(github.ref, 'refs/heads/release-') }}
         with:
           input: apis
-          against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=master,subdir=apis"
+          against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=main,subdir=apis"
 
       - name: Detect Breaking Changes in Protocol Buffers (Release Branch)
         uses: bufbuild/buf-breaking-action@a074e988ee34efcd4927079e79c611f428354c01 # v1
@@ -485,7 +498,7 @@ jobs:
           against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=${GITHUB_REF_NAME},subdir=apis"
 
       - name: Push Protocol Buffers to Buf Schema Registry
-        if: ${{ github.repository == 'crossplane/crossplane' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-')) }}
+        if: ${{ github.repository == 'crossplane/crossplane' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-')) }}
         uses: bufbuild/buf-push-action@v1
         with:
           input: apis

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ KIND_VERSION = v0.21.0
 # Due to the way that the shared build logic works, images should
 # all be in folders at the same level (no additional levels of nesting).
 
-REGISTRY_ORGS ?= docker.io/upbound xpkg.upbound.io/upbound xpkg.upbound.io/spaces-artifacts
+REGISTRY_ORGS ?= docker.io/upbound xpkg.upbound.io/upbound
 IMAGES = crossplane
 -include build/makelib/imagelight.mk
 


### PR DESCRIPTION
### Description of your changes

Follow up on https://github.com/upbound/crossplane/pull/132

[Looks like](https://github.com/upbound/crossplane/actions/runs/10833197243/job/30059392574), we cannot login to multiple orgs in Upbound marketplace with their tokens and push them. It looks like the latter login overrides the previous ones.

![image](https://github.com/user-attachments/assets/98d80e75-9e68-438c-950c-5d6ff240a357)

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~Run `make reviewable` to ensure this PR is ready for review.~
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/master/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/master/contributing#checklist-cheat-sheet
