### PR TITLE
Fix crossplane internal version in ci

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -147,11 +147,12 @@ go-build:
   ARG EARTHLY_GIT_SHORT_HASH
   ARG EARTHLY_GIT_COMMIT_TIMESTAMP
   ARG CROSSPLANE_VERSION=v0.0.0-${EARTHLY_GIT_COMMIT_TIMESTAMP}-${EARTHLY_GIT_SHORT_HASH}
+  ARG CROSSPLANE_INTERNAL_VERSION=${CROSSPLANE_VERSION}
   ARG TARGETARCH
   ARG TARGETOS
   ARG GOARCH=${TARGETARCH}
   ARG GOOS=${TARGETOS}
-  ARG GOFLAGS="-ldflags=-X=github.com/crossplane/crossplane/internal/version.version=${CROSSPLANE_VERSION}"
+  ARG GOFLAGS="-ldflags=-X=github.com/crossplane/crossplane/internal/version.version=${CROSSPLANE_INTERNAL_VERSION}"
   ARG CGO_ENABLED=0
   FROM +go-modules
   LET ext = ""
@@ -345,7 +346,8 @@ helm-setup:
 # ci-version is used by CI to set the CROSSPLANE_VERSION environment variable.
 ci-version:
   LOCALLY
-  RUN echo "CROSSPLANE_VERSION=$(git describe --dirty --always --tags|sed -e 's/-/./2g'|sed 's/[\.,-]up.*//')" > $GITHUB_ENV
+  RUN echo "CROSSPLANE_VERSION=$(git describe --dirty --always --tags|sed -e 's/-/./2g')" > $GITHUB_ENV
+  RUN echo "CROSSPLANE_INTERNAL_VERSION=$(git describe --dirty --always --tags|sed -e 's/-/./2g'|sed -e 's/[\.,-]up.*//')" >> $GITHUB_ENV
 
 # ci-artifacts is used by CI to build and push the Crossplane image, chart, and
 # binaries.


### PR DESCRIPTION
### Description of your changes

Currently it ends up with a upbound/crossplane image tagged as v1.17.0 for a tag v1.17.0-up.1. Image tag should not be effected, only internal Crossplane version should.

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
