### PR TITLE
Pass crossplane internal version to earthly call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,11 +328,11 @@ jobs:
         if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-')) && env.DOCKER_USR != '' && env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != ''
         run: echo "EARTHLY_PUSH=true" >> $GITHUB_ENV
 
-      - name: Set CROSSPLANE_VERSION GitHub Environment Variable
+      - name: Set CROSSPLANE_VERSION and CROSSPLANE_INTERNAL_VERSION GitHub Environment Variables
         run: earthly +ci-version
 
       - name: Build and Push Artifacts
-        run: earthly --strict --remote-cache ghcr.io/upbound/crossplane-earthly-cache:${{ github.job }} +ci-artifacts --CROSSPLANE_VERSION=${CROSSPLANE_VERSION}
+        run: earthly --strict --remote-cache ghcr.io/upbound/crossplane-earthly-cache:${{ github.job }} +ci-artifacts --CROSSPLANE_VERSION=${CROSSPLANE_VERSION} --CROSSPLANE_INTERNAL_VERSION=${CROSSPLANE_INTERNAL_VERSION}
 
       - name: Upload Artifacts to GitHub
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4


### PR DESCRIPTION
### Description of your changes

Follow up on https://github.com/upbound/crossplane/pull/138

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [x] Added `backport release-x.y` labels to auto-backport this PR.

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
