### PR TITLE
Fix earthly cache for upbound/crossplane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,7 +315,7 @@ jobs:
           timeout_minutes: 45  # Per attempt
           max_attempts: 3
           command: |
-            earthly --strict --allow-privileged --remote-cache ghcr.io/upbound/earthly-cache:${{ github.job }}-${{ matrix.test-area}}-${{ matrix.test-suite}} \
+            earthly --strict --allow-privileged --remote-cache ghcr.io/upbound/crossplane-earthly-cache:${{ github.job }}-${{ matrix.test-area}}-${{ matrix.test-suite}} \
               +e2e --GOTESTSUM_FORMAT="testname" --FLAGS="-test.failfast -fail-fast -prior-crossplane-version=${CROSSPLANE_PRIOR_VERSION} --test-suite ${{ matrix.test-suite }} -labels area=${{ matrix.test-area }}"
 
       - name: Publish E2E Test Flakes


### PR DESCRIPTION
### Description of your changes

It looks like I made a mistake while resolving the only conflict in #162 

<img width="1586" height="293" alt="Screenshot 2025-07-15 at 12 14 30" src="https://github.com/user-attachments/assets/9fb0a58a-3997-4bc8-aef9-1c6e80294b03" />

All e2e's on main failing with:

<img width="1545" height="206" alt="Screenshot 2025-07-15 at 12 16 17" src="https://github.com/user-attachments/assets/91f46310-6842-4bb7-8b1d-71c4b2369bfb" />

I have: <!--You MUST either [x] check or [ ] ~strike through~ every item.-->

- [ ] ~Read and followed Crossplane's [contribution process].~
- [x] Run `earthly +reviewable` to ensure this PR is ready for review.
- [ ] ~Added or updated unit tests.~
- [ ] ~Added or updated e2e tests.~
- [ ] ~Linked a PR or a [docs tracking issue] to [document this change].~
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR.~
- [ ] ~Followed the [API promotion workflow] if this PR introduces, removes, or promotes an API.~

Need help with this checklist? See the [cheat sheet].

[contribution process]: https://github.com/crossplane/crossplane/tree/main/contributing
[docs tracking issue]: https://github.com/crossplane/docs/issues/new
[document this change]: https://docs.crossplane.io/contribute/contribute
[cheat sheet]: https://github.com/crossplane/crossplane/tree/main/contributing#checklist-cheat-sheet
[API promotion workflow]: https://github.com/crossplane/crossplane/blob/main/contributing/guide-api-promotion.md